### PR TITLE
Update lite-vimeo.ts

### DIFF
--- a/lite-vimeo.ts
+++ b/lite-vimeo.ts
@@ -133,6 +133,7 @@ export class LiteVimeoEmbed extends HTMLElement {
           position: absolute;
           width: 100%;
           height: 100%;
+          left: 0;
         }
 
         #frame {


### PR DESCRIPTION
Added a `left: 0;` rule for the cover poster image, as mobile browsers were setting this to left: 50% by default (or showing it that way).

Without this rule the poster image starts 50% into the video container, leaving the first half of the video empty.